### PR TITLE
Improve doc examples

### DIFF
--- a/Example/FlexLayoutSample/UI/Examples/RaywenderlichTutorial/RaywenderlichTutorialView.swift
+++ b/Example/FlexLayoutSample/UI/Examples/RaywenderlichTutorial/RaywenderlichTutorialView.swift
@@ -90,42 +90,42 @@ class RayWenderlichTutorialView: BaseView {
             flex.addItem(episodeImageView).grow(1).backgroundColor(.gray)
             
             // Summary row
-            flex.addItem().direction(.row).padding(padding).define({ (flex) in
+            flex.addItem().direction(.row).padding(padding).define { (flex) in
                 flex.addItem(summaryPopularityLabel).grow(1)
                 
-                flex.addItem().direction(.row).justifyContent(.spaceBetween).grow(2).define({ (flex) in
+                flex.addItem().direction(.row).justifyContent(.spaceBetween).grow(2).define { (flex) in
                     flex.addItem(yearLabel)
                     flex.addItem(ratingLabel)
                     flex.addItem(lengthLabel)
-                })
+                }
                 
                 flex.addItem().width(100).height(1).grow(1)
-            })
+            }
             
             // Title row
-            flex.addItem().direction(.row).padding(padding).define({ (flex) in
+            flex.addItem().direction(.row).padding(padding).define { (flex) in
                 flex.addItem(episodeIdLabel)
                 flex.addItem(episodeTitleLabel).marginLeft(20)
-            })
+            }
             
             // Description section
-            flex.addItem().paddingHorizontal(paddingHorizontal).define({ (flex) in
+            flex.addItem().paddingHorizontal(paddingHorizontal).define { (flex) in
                 flex.addItem(descriptionLabel)
                 flex.addItem(castLabel)
                 flex.addItem(creatorsLabel)
-            })
+            }
             
             // Action row
-            flex.addItem().direction(.row).padding(padding).define({ (flex) in
+            flex.addItem().direction(.row).padding(padding).define { (flex) in
                 flex.addItem(addActionView)
                 flex.addItem(shareActionView)
-            })
+            }
             
             // Tabs row
-            flex.addItem().direction(.row).padding(padding).define({ (flex) in
+            flex.addItem().direction(.row).padding(padding).define { (flex) in
                 flex.addItem(episodesTabView)
                 flex.addItem(moreTabView)
-            })
+            }
             
             // Shows TableView
             flex.addItem(showsTableView).grow(1)

--- a/Example/FlexLayoutSample/UI/Examples/TableViewExample/Subviews/MethodCell.swift
+++ b/Example/FlexLayoutSample/UI/Examples/TableViewExample/Subviews/MethodCell.swift
@@ -39,10 +39,10 @@ class MethodCell: UITableViewCell {
 
         // Use contentView as the root flex container
         contentView.flex.padding(8).define { (flex) in
-            flex.addItem().direction(.row).define({ (flex) in
+            flex.addItem().direction(.row).define { (flex) in
                 flex.addItem(iconImageView).size(30)
                 flex.addItem(nameLabel).marginLeft(padding).grow(1)
-            })
+            }
 
             flex.addItem(descriptionLabel).marginTop(padding)
         }

--- a/Example/FlexLayoutSample/UI/Examples/YogaExampleE/YogaExampleEView.swift
+++ b/Example/FlexLayoutSample/UI/Examples/YogaExampleE/YogaExampleEView.swift
@@ -29,10 +29,10 @@ class YogaExampleEView: BaseView {
         rootFlexContainer.flex.define { (flex) in
             flex.addItem(imageView).grow(1)
             
-            flex.addItem().direction(.row).padding(20).alignItems(.center).define({ (flex) in
+            flex.addItem().direction(.row).padding(20).alignItems(.center).define { (flex) in
                 flex.addItem().size(50).backgroundColor(.flexLayoutColor)
                 flex.addItem().height(25).marginStart(20).grow(1).backgroundColor(.black)
-            })
+            }
         }
         addSubview(rootFlexContainer)
     }

--- a/README.md
+++ b/README.md
@@ -144,42 +144,42 @@ init() {
         flex.addItem(episodeImageView).grow(1).backgroundColor(.gray)
         
         // Summary row
-        flex.addItem().direction(.row).padding(padding).define({ (flex) in
+        flex.addItem().direction(.row).padding(padding).define { (flex) in
             flex.addItem(summaryPopularityLabel).grow(1)
             
-            flex.addItem().direction(.row).justifyContent(.spaceBetween).grow(2).define({ (flex) in
+            flex.addItem().direction(.row).justifyContent(.spaceBetween).grow(2).define { (flex) in
                 flex.addItem(yearLabel)
                 flex.addItem(ratingLabel)
                 flex.addItem(lengthLabel)
-            })
+            }
             
             flex.addItem().width(100).height(1).grow(1)
-        })
+        }
         
         // Title row
-        flex.addItem().direction(.row).padding(padding).define({ (flex) in
+        flex.addItem().direction(.row).padding(padding).define { (flex) in
             flex.addItem(episodeIdLabel)
             flex.addItem(episodeTitleLabel).marginLeft(20)
-        })
+        }
         
         // Description section
-        flex.addItem().paddingHorizontal(paddingHorizontal).define({ (flex) in
+        flex.addItem().paddingHorizontal(paddingHorizontal).define { (flex) in
             flex.addItem(descriptionLabel)
             flex.addItem(castLabel)
             flex.addItem(creatorsLabel)
-        })
+        }
         
         // Action row
-        flex.addItem().direction(.row).padding(padding).define({ (flex) in
+        flex.addItem().direction(.row).padding(padding).define { (flex) in
             flex.addItem(addActionView)
             flex.addItem(shareActionView)
-        })
+        }
         
         // Tabs row
-        flex.addItem().direction(.row).padding(padding).define({ (flex) in
+        flex.addItem().direction(.row).padding(padding).define { (flex) in
             flex.addItem(episodesTabView)
             flex.addItem(moreTabView)
-        })
+        }
         
         // Shows TableView
         flex.addItem(showsTableView).grow(1)

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ This example creates a flexbox container and sets its alpha to 0.8.
 
 ```swift
     view.flex.direction(.row).padding(20).alignItems(.center).define { (flex) in
-        flex.createBox().width(50).height(50).define { (flex) in
+        flex.addItem().width(50).height(50).define { (flex) in
             flex.view.alpha = 0.8
         }
     }
@@ -397,7 +397,7 @@ Another possible solution:
         let container = UIView()
         container.alpha = 0.8
         
-        flex.addChild(container).width(50).height(50)
+        flex.addItem(container).width(50).height(50)
     }
 ``` 
 <br>

--- a/README.md
+++ b/README.md
@@ -383,22 +383,22 @@ It is possible to access the flex items's UIView using `flex.view`. This is part
 This example creates a flexbox container and sets its alpha to 0.8.
 
 ```swift
-    flex.createBox().direction(.row).padding(20).alignItems(.center).define({ (flex) in
-        flex.createBox().width(50).height(50).define({ (flex) in
+    view.flex.direction(.row).padding(20).alignItems(.center).define { (flex) in
+        flex.createBox().width(50).height(50).define { (flex) in
             flex.view.alpha = 0.8
-        }}
-    })
+        }
+    }
 ``` 
 
 Another possible solution:
 
 ```swift
-    flex.createBox().direction(.row).padding(20).alignItems(.center).define({ (flex) in
+    view.flex.direction(.row).padding(20).alignItems(.center).define { (flex) in
         let container = UIView()
         container.alpha = 0.8
         
         flex.addChild(container).width(50).height(50)
-    })
+    }
 ``` 
 <br>
 


### PR DESCRIPTION
This makes using trailing closure syntax in define method consistent in all examples. 
Also createBox method was removed from README because it doesn't exist anymore.