### PR TITLE
Mark Flex class as final

### DIFF
--- a/Sources/FlexLayout.swift
+++ b/Sources/FlexLayout.swift
@@ -26,7 +26,7 @@ import UIKit
     label.flex.margin(10)
  ```
  */
-public class Flex {
+public final class Flex {
     
     //
     // MARK: Properties


### PR DESCRIPTION
Hi!

This breaks backward compatibility, but I think nobody created subclasses of Flex class anyway.

It improves performance a little bit by dispatching method calls statically. Also compiler can apply other optimizations, such as inlining. Usually we have a lot of chain calls with small methods and inlining optimization in this case works perfect.