### PR TITLE
Rounding behaviour

### DIFF
--- a/Sources/YogaKit/YGLayout.mm
+++ b/Sources/YogaKit/YGLayout.mm
@@ -337,8 +337,8 @@ static YGSize YGMeasureView(
   }];
 
   return (YGSize) {
-    .width = (YGUnit) YGSanitizeMeasurement(constrainedWidth, sizeThatFits.width, widthMode),
-    .height = (YGUnit) YGSanitizeMeasurement(constrainedHeight, sizeThatFits.height, heightMode),
+    .width = (float) YGSanitizeMeasurement(constrainedWidth, sizeThatFits.width, widthMode),
+    .height = (float) YGSanitizeMeasurement(constrainedHeight, sizeThatFits.height, heightMode),
   };
 }
 

--- a/Sources/YogaKit/YGLayout.mm
+++ b/Sources/YogaKit/YGLayout.mm
@@ -116,12 +116,12 @@ YG_VALUE_EDGE_PROPERTY(lowercased_name, capitalized_name, capitalized_name, YGEd
 
 YGValue YGPointValue(CGFloat value)
 {
-  return (YGValue) { .value = (YGUnit) value, .unit = (YGUnit) YGUnitPoint };
+  return (YGValue) { .value = (float) value, .unit = (YGUnit) YGUnitPoint };
 }
 
 YGValue YGPercentValue(CGFloat value)
 {
-  return (YGValue) { .value = (YGUnit) value, .unit = YGUnitPercent };
+  return (YGValue) { .value = (float) value, .unit = YGUnitPercent };
 }
 
 static YGConfigRef globalConfig;

--- a/core-tests/YGPixelGridRounding.cpp
+++ b/core-tests/YGPixelGridRounding.cpp
@@ -1,7 +1,11 @@
 #include <gtest/gtest.h>
 #include <yoga/Yoga.h>
 
-// This tests
+// This test scrutinize next behaviours:
+// - pixel grid snapping in 1e4..0 coordinate range
+// - ability to layout nodes with smallest possible dimensions (one pixel separators)
+// - providing text node layout with bounds strictly larger than sized
+
 TEST(YogaTest, pixel_grid_rounding_table) {
   const float kPointScale = 3;
 

--- a/core-tests/YGPixelGridRounding.cpp
+++ b/core-tests/YGPixelGridRounding.cpp
@@ -13,7 +13,7 @@ TEST(YogaTest, pixel_grid_rounding_table) {
   YGConfigSetPointScaleFactor(config, kPointScale);
 
   const float kSeparatorHeight = 1 / kPointScale;
-  const float kCellContentHeight = 100.5;
+  const float kCellContentHeight = 44.5;
   const int kCellsCount = 100;
 
   const YGNodeRef root = YGNodeNewWithConfig(config);

--- a/core-tests/YGPixelGridRounding.cpp
+++ b/core-tests/YGPixelGridRounding.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+#include <yoga/Yoga.h>
+
+// This tests
+TEST(YogaTest, pixel_grid_rounding_table) {
+  const float kPointScale = 3;
+
+  const YGConfigRef config = YGConfigNew();
+  YGConfigSetPointScaleFactor(config, kPointScale);
+
+  const float kSeparatorHeight = 1 / kPointScale;
+  const float kCellContentHeight = 100.5;
+  const int kCellsCount = 100;
+
+  const YGNodeRef root = YGNodeNewWithConfig(config);
+
+  int subnodesCount = 0;
+
+  for (int i = 0; i < kCellsCount; i++) {
+    const YGNodeRef separator = YGNodeNewWithConfig(config);
+    YGNodeStyleSetHeight(separator, kSeparatorHeight);
+    YGNodeInsertChild(root, separator, subnodesCount++);
+
+    const YGNodeRef cell = YGNodeNewWithConfig(config);
+    YGNodeSetNodeType(cell, YGNodeTypeText);
+    YGNodeStyleSetHeight(cell, kCellContentHeight);
+    YGNodeInsertChild(root, cell, subnodesCount++);
+  }
+
+  const YGNodeRef separator = YGNodeNewWithConfig(config);
+  YGNodeStyleSetHeight(separator, kSeparatorHeight);
+  YGNodeInsertChild(root, separator, subnodesCount++);
+
+  YGNodeCalculateLayout(root, 375, YGUndefined, YGDirectionLTR);
+
+  EXPECT_LE(kCellsCount * (kSeparatorHeight + kCellContentHeight) + kSeparatorHeight, YGNodeLayoutGetHeight(root));
+  EXPECT_FLOAT_EQ(375, YGNodeLayoutGetWidth(root));
+
+  for (int i = 0; i < YGNodeGetChildCount(root); i++) {
+    const YGNodeRef child = YGNodeGetChild(root, i);
+    const float childHeight = YGNodeLayoutGetHeight(child);
+
+    if (YGNodeGetNodeType(child) == YGNodeTypeText) {
+      EXPECT_GT(childHeight, kCellContentHeight);
+    } else {
+      EXPECT_GT(childHeight, 0);
+    }
+  }
+
+  YGNodeFreeRecursive(root);
+
+  YGConfigFree(config);
+}

--- a/core-tests/YGRoundingFunctionTest.cpp
+++ b/core-tests/YGRoundingFunctionTest.cpp
@@ -19,10 +19,15 @@ TEST(YogaTest, rounding_value) {
   ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(5.999999, 2.0, false, true));
 
   // Test that numbers with fraction are rounded correctly accounting for ceil/floor flags
-  ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(6.01, 2.0, false, false));
-  ASSERT_FLOAT_EQ(6.5, YGRoundValueToPixelGrid(6.01, 2.0, true, false));
-  ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(6.01, 2.0, false, true));
-  ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(5.99, 2.0, false, false));
-  ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(5.99, 2.0, true, false));
-  ASSERT_FLOAT_EQ(5.5, YGRoundValueToPixelGrid(5.99, 2.0, false, true));
+  ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(6.1, 2.0, false, false));
+  ASSERT_FLOAT_EQ(6.5, YGRoundValueToPixelGrid(6.1, 2.0, true, false));
+  ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(6.1, 2.0, false, true));
+  ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(5.9, 2.0, false, false));
+  ASSERT_FLOAT_EQ(6.0, YGRoundValueToPixelGrid(5.9, 2.0, true, false));
+  ASSERT_FLOAT_EQ(5.5, YGRoundValueToPixelGrid(5.9, 2.0, false, true));
+
+  // Are we able to treat value as rounded for reasonably large number?
+  ASSERT_FLOAT_EQ(527.6666666, YGRoundValueToPixelGrid(527.666, 3.0, false, true));
+  ASSERT_FLOAT_EQ(527.6666666, YGRoundValueToPixelGrid(527.666, 3.0, true, false));
+  ASSERT_FLOAT_EQ(527.6666666, YGRoundValueToPixelGrid(527.666, 3.0, true, true));
 }


### PR DESCRIPTION
This PR fixes number of rounding issues:
- [x] Integer truncation of sizes calculated by `sizeThatFits:`, and utility functions. Introduced by Obj-C -> Obj-C++ conversion in previous PR
- [x] Low coordinate rounding threshold, which results in flooring apparently valid values. Layout becomes very wrong with absolute coordinate values larger than 100 and having pointScaleFactor set to 3.



#
![](https://media0.giphy.com/media/pziV12OyKYOoE/giphy.gif)