### PR TITLE
Fix retain cycle

### DIFF
--- a/FlexLayoutTests/FlexLayoutTests.swift
+++ b/FlexLayoutTests/FlexLayoutTests.swift
@@ -15,26 +15,15 @@ import XCTest
 
 class FlexLayoutTests: XCTestCase {
     
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    func testRetainCycle() {
+        weak var weakView: UIView? = nil
+        _ = { _ in
+            let strongView = UIView()
+            strongView.flex.direction(.column)
+            weakView = strongView
+        }()
+        
+        XCTAssertNil(weakView, "Creation of flex should not lead to retain cycle")
     }
     
 }

--- a/Sources/FlexLayout.swift
+++ b/Sources/FlexLayout.swift
@@ -31,7 +31,7 @@ public final class Flex {
     /**
      Flex items's UIView.
     */
-    private weak var view: UIView?
+    private(set) weak var view: UIView?
     private let yoga: YGLayout
     
     /**

--- a/Sources/FlexLayout.swift
+++ b/Sources/FlexLayout.swift
@@ -31,7 +31,7 @@ public final class Flex {
     /**
      Flex items's UIView.
     */
-    public let view: UIView
+    private weak var view: UIView?
     private let yoga: YGLayout
     
     /**
@@ -73,8 +73,12 @@ public final class Flex {
      */
     @discardableResult
     public func addItem(_ view: UIView) -> Flex {
-        self.view.addSubview(view)
-        return view.flex
+        if let host = self.view {
+            host.addSubview(view)
+            return view.flex
+        } else {
+            preconditionFailure("Trying to modify deallocated host view")
+        }
     }
 
     /**
@@ -954,8 +958,12 @@ public final class Flex {
     */
     @discardableResult
     public func backgroundColor(_ color: UIColor) -> Flex {
-        view.backgroundColor = color
-        return self
+        if let host = self.view {
+            host.backgroundColor = color
+            return self
+        } else {
+            preconditionFailure("Trying to modify deallocated host view")
+        }
     }
     
     // MARK: Enums


### PR DESCRIPTION
This PR introduces two changes:

Now `view` of `Flex` is hidden, because it's a weak variable, and users of `Flex` may brake this state. I think in practice it's rare to see `Flex` being cached far away from it's hosting view, so this shouldn't be a problem.

Now `Flex` don't hold strong reference to it's hosting view, as this introduce retain cycle.