### PR TITLE
Revert the change that makes the `Flex` class `final.

### DIFF
--- a/Sources/FlexLayout.swift
+++ b/Sources/FlexLayout.swift
@@ -22,7 +22,7 @@ import UIKit
     label.flex.margin(10)
  ```
  */
-public final class Flex {
+public class Flex {
     
     //
     // MARK: Properties


### PR DESCRIPTION
Setting the Flex class as `final` didn't improve the performance (see benchmark result below), but it was disabling the capabilities of using extensions to extend the Flex class. 

For that reason we revert this change.

The performance has been tested using https://github.com/layoutBox/LayoutFrameworkBenchmark
The difference in performance are in the margin error zone.

![screen shot 2018-03-06 at 8 49 47 am](https://user-images.githubusercontent.com/14981341/37035710-634b3ce4-211b-11e8-9a9e-1bb3ba9bcca3.png)

**Benchmark raw result:**

FlexLayout with final | 0.007929842303118 | 0.01076659207703 | 0.014009190930261 | 0.017830131346719 | 0.020426526361582 | 0.023774271787599 | 0.027051071862917 | 0.030010559979607 | 0.033361705144246 | 0.036379597016743
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
FlexLayout without final | 0.008002404212952 | 0.010761662196088 | 0.014033155308829 | 0.017201821682817 | 0.020557583594809 | 0.023768768754116 | 0.026775419712067 | 0.029985887162826 | 0.033210677485312 | 0.036419859954289
Auto Layout | 0.032791841414667 | 0.052712321281433 | 0.073919355869293 | 0.09501500563188 | 0.116849793328179 | 0.140826880931854 | 0.164986286844526 | 0.184662818908691 | 0.201913189888 | 0.223486995697021

