### PR TITLE
Add methods to position edges using percentage parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,21 +766,21 @@ The position property tells Flexbox how you want your item to be positioned with
 ```
 
 ### top(), bottom(), left(), right(), start(), end()
-A flex item which is `position` is set to `.absolute` is positioned absolutely in regards to its parent. This is done through 6 properties:
+A flex item which is `position` is set to `.absolute` is positioned absolutely in regards to its parent. This is done through the following methods:
 
 **Methods:**
 
-* **`top( value: CGFloat)`**:  
-Controls the distance a child’s top edge is from the parent’s top edge
-* **`bottom( value: CGFloat)`**:  
-Controls the distance a child’s bottom edge is from the parent’s bottom edge
-* **`left( value: CGFloat)`**:  
-Controls the distance a child’s left edge is from the parent’s left edge
-* **`right( value: CGFloat)`**:  
-Controls the distance a child’s right edge is from the parent’s right edge
-* **`start( value: CGFloat)`**:  
+* **`top(: CGFloat)`** / **`top(: FPercent)`**:  
+Controls the distance a child’s top edge is from the parent’s top edge.
+* **`bottom(: CGFloat)`** / **`bottom(: FPercent)`**:  
+Controls the distance a child’s bottom edge is from the parent’s bottom edge.
+* **`left(: CGFloat)`** / **`left(: FPercent)`**:  
+Controls the distance a child’s left edge is from the parent’s left edge.
+* **`right(: CGFloat)`** / **`right(: FPercent)`**:  
+Controls the distance a child’s right edge is from the parent’s right edge.
+* **`start(: CGFloat)`** / **`start(: FPercent)`**:  
 Controls the distance a child’s start edge is from the parent’s start edge. In left-to-right direction (LTR), it corresponds to the `left()` property and in RTL to `right()` property.
-* **`end( value: CGFloat)`**:  
+* **`end(: CGFloat)`** / **`end(: FPercent)`**:  
 Controls the distance a child’s end edge is from the parent’s end edge. In left-to-right direction (LTR), it corresponds to the `right()` property and in RTL to `left()` property.
 
 Using these properties you can control the size and position of an absolute item within its parent. Because absolutely positioned children don’t affect their sibling's layout. Absolute position can be used to create overlays and stack children in the Z axis.
@@ -788,6 +788,7 @@ Using these properties you can control the size and position of an absolute item
 ###### Usage examples:
 ```swift
   view.flex.position(.absolute).top(10).right(10).width(100).height(50)
+  view.flex.position(.absolute).left(20%).right(20%)
 ```
 :pushpin: See the "Yoga C" example in the [Examples App](#examples_app). [Source code](https://github.com/layoutBox/FlexLayout/blob/master/Example/FlexLayoutSample/UI/Examples/YogaExampleC/YogaExampleCView.swift)
 

--- a/Sources/FlexLayout.swift
+++ b/Sources/FlexLayout.swift
@@ -512,6 +512,7 @@ public final class Flex {
     
     /**
      Set the left edge distance from the container left edge in pixels.
+     This method is valid only when the item position is absolute (`view.flex.position(.absolute)`)
      */
     @discardableResult
     public func left(_ value: CGFloat) -> Flex {
@@ -521,6 +522,7 @@ public final class Flex {
 
     /**
      Set the left edge distance from the container left edge in percentage of its container width.
+     This method is valid only when the item position is absolute (`view.flex.position(.absolute)`)
      */
     @discardableResult
     public func left(_ percent: FPercent) -> Flex {
@@ -530,6 +532,7 @@ public final class Flex {
     
     /**
      Set the top edge distance from the container top edge in pixels.
+     This method is valid only when the item position is absolute (`view.flex.position(.absolute)`)
      */
     @discardableResult
     public func top(_ value: CGFloat) -> Flex {
@@ -539,6 +542,7 @@ public final class Flex {
 
     /**
      Set the top edge distance from the container top edge in percentage of its container height.
+     This method is valid only when the item position is absolute (`view.flex.position(.absolute)`)
      */
     @discardableResult
     public func top(_ percent: FPercent) -> Flex {
@@ -548,6 +552,7 @@ public final class Flex {
     
     /**
      Set the right edge distance from the container right edge in pixels.
+     This method is valid only when the item position is absolute (`view.flex.position(.absolute)`)
      */
     @discardableResult
     public func right(_ value: CGFloat) -> Flex {
@@ -557,6 +562,7 @@ public final class Flex {
 
     /**
      Set the right edge distance from the container right edge in percentage of its container width.
+     This method is valid only when the item position is absolute (`view.flex.position(.absolute)`)
      */
     @discardableResult
     public func right(_ percent: FPercent) -> Flex {
@@ -566,6 +572,7 @@ public final class Flex {
 
     /**
      Set the bottom edge distance from the container bottom edge in pixels.
+     This method is valid only when the item position is absolute (`view.flex.position(.absolute)`)
      */
     @discardableResult
     public func bottom(_ value: CGFloat) -> Flex {
@@ -575,6 +582,7 @@ public final class Flex {
 
     /**
      Set the bottom edge distance from the container bottom edge in percentage of its container height.
+     This method is valid only when the item position is absolute (`view.flex.position(.absolute)`)
      */
     @discardableResult
     public func bottom(_ percent: FPercent) -> Flex {
@@ -584,6 +592,7 @@ public final class Flex {
     
     /**
      Set the start edge (LTR=left, RTL=right) distance from the container start edge in pixels.
+     This method is valid only when the item position is absolute (`view.flex.position(.absolute)`)
      */
     @discardableResult
     public func start(_ value: CGFloat) -> Flex {
@@ -594,6 +603,7 @@ public final class Flex {
     /**
      Set the start edge (LTR=left, RTL=right) distance from the container start edge in
      percentage of its container width.
+     This method is valid only when the item position is absolute (`view.flex.position(.absolute)`)
      */
     @discardableResult
     public func start(_ percent: FPercent) -> Flex {
@@ -603,6 +613,7 @@ public final class Flex {
     
     /**
      Set the end edge (LTR=right, RTL=left) distance from the container end edge in pixels.
+     This method is valid only when the item position is absolute (`view.flex.position(.absolute)`)
      */
     @discardableResult
     public func end(_ value: CGFloat) -> Flex {
@@ -613,6 +624,7 @@ public final class Flex {
     /**
      Set the end edge (LTR=right, RTL=left) distance from the container end edge in
      percentage of its container width.
+     This method is valid only when the item position is absolute (`view.flex.position(.absolute)`)
      */
     @discardableResult
     public func end(_ percent: FPercent) -> Flex {

--- a/Sources/FlexLayout.swift
+++ b/Sources/FlexLayout.swift
@@ -518,6 +518,15 @@ public final class Flex {
         yoga.left = YGValue(value)
         return self
     }
+
+    /**
+     Set the left edge distance from the container left edge in percentage of its container width.
+     */
+    @discardableResult
+    public func left(_ percent: FPercent) -> Flex {
+        yoga.left = YGValue(value: Float(percent.value), unit: .percent)
+        return self
+    }
     
     /**
      Set the top edge distance from the container top edge in pixels.
@@ -525,6 +534,15 @@ public final class Flex {
     @discardableResult
     public func top(_ value: CGFloat) -> Flex {
         yoga.top = YGValue(value)
+        return self
+    }
+
+    /**
+     Set the top edge distance from the container top edge in percentage of its container height.
+     */
+    @discardableResult
+    public func top(_ percent: FPercent) -> Flex {
+        yoga.top = YGValue(value: Float(percent.value), unit: .percent)
         return self
     }
     
@@ -536,13 +554,31 @@ public final class Flex {
         yoga.right = YGValue(value)
         return self
     }
-    
+
+    /**
+     Set the right edge distance from the container right edge in percentage of its container width.
+     */
+    @discardableResult
+    public func right(_ percent: FPercent) -> Flex {
+        yoga.right = YGValue(value: Float(percent.value), unit: .percent)
+        return self
+    }
+
     /**
      Set the bottom edge distance from the container bottom edge in pixels.
      */
     @discardableResult
     public func bottom(_ value: CGFloat) -> Flex {
         yoga.bottom = YGValue(value)
+        return self
+    }
+
+    /**
+     Set the bottom edge distance from the container bottom edge in percentage of its container height.
+     */
+    @discardableResult
+    public func bottom(_ percent: FPercent) -> Flex {
+        yoga.bottom = YGValue(value: Float(percent.value), unit: .percent)
         return self
     }
     
@@ -554,13 +590,33 @@ public final class Flex {
         yoga.start = YGValue(value)
         return self
     }
+
+    /**
+     Set the start edge (LTR=left, RTL=right) distance from the container start edge in
+     percentage of its container width.
+     */
+    @discardableResult
+    public func start(_ percent: FPercent) -> Flex {
+        yoga.start = YGValue(value: Float(percent.value), unit: .percent)
+        return self
+    }
     
     /**
-     Set the end edge (LTR=right, RTL=left) distance from the container start edge in pixels.
+     Set the end edge (LTR=right, RTL=left) distance from the container end edge in pixels.
      */
     @discardableResult
     public func end(_ value: CGFloat) -> Flex {
         yoga.end = YGValue(value)
+        return self
+    }
+
+    /**
+     Set the end edge (LTR=right, RTL=left) distance from the container end edge in
+     percentage of its container width.
+     */
+    @discardableResult
+    public func end(_ percent: FPercent) -> Flex {
+        yoga.end = YGValue(value: Float(percent.value), unit: .percent)
         return self
     }
     


### PR DESCRIPTION
These methods are valid only when the item position is absolute (`view.flex.position(.absolute)`)
New methods:
* `left(: FPercent)`
* `right(: FPercent)`
* `start(: FPercent)`
* `end(: FPercent)`
* `top(: FPercent)`
* `bottom(: FPercent)`