### PR TITLE
[bug fix] delegate isIncludedInLayout to yoga vs using default value

### DIFF
--- a/Sources/FlexLayout.swift
+++ b/Sources/FlexLayout.swift
@@ -116,9 +116,12 @@ public final class Flex {
      This property controls dynamically if a flexbox's UIView is included or not in the flexbox layouting. When a
      flexbox's UIView is excluded, FlexLayout won't layout the view and its children views.
     */
-    public var isIncludedInLayout: Bool = true {
-        didSet {
-            yoga.isIncludedInLayout = isIncludedInLayout
+    public var isIncludedInLayout: Bool {
+        get {
+            return yoga.isIncludedInLayout
+        }
+        set {
+            yoga.isIncludedInLayout = newValue
         }
     }
     


### PR DESCRIPTION
Currently the value of `isIncludedInLayout` may not reflect what the underlying yoga value is as the developer may have manipulated the `yoga` value directly. This could potentially leave the Flex initial value out of sync. This change defers the get/set of this property to yoga.