### PR TITLE
Update Swift Package to be compatible with Xcode 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
iOS 8 is being an unsupported deployment target. 
Increasing the deployment target to iOS 9 in the Package.swift resolves the issue.

```
FlexLayout/Package.swift The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' 
is set to 8.0, but the range of supported deployment target versions is 9.0 to 15.0.99.
```