### PR TITLE
Round pixel values of `intrinsicSize` with `YGRoundPixelValue`

### DIFF
--- a/Sources/YogaKit/YGLayout.mm
+++ b/Sources/YogaKit/YGLayout.mm
@@ -309,11 +309,15 @@ YG_PROPERTY(CGFloat, aspectRatio, AspectRatio)
 
 - (CGSize)intrinsicSize
 {
-  const CGSize constrainedSize = {
+  CGSize constrainedSize = {
     .width = YGUndefined,
     .height = YGUndefined,
   };
-  return [self calculateLayoutWithSize:constrainedSize];
+  constrainedSize = [self calculateLayoutWithSize:constrainedSize];
+  return (CGSize){
+    .width = YGRoundPixelValue(constrainedSize.width),
+    .height = YGRoundPixelValue(constrainedSize.height),
+  };
 }
 
 - (CGSize)calculateLayoutWithSize:(CGSize)size


### PR DESCRIPTION
This PR makes `intrinsicSize` return rounded pixel values using `YGRoundPixelValue` as `YGApplyLayoutToViewHierarchy` does. (propagation of https://github.com/facebook/yoga/pull/1213)

This change prevents text truncation due to the low precision of C++ `float` when sizing the view containing `UILabel` using `intinsicSize`.

```swift
override func sizeToFit() {
  self.bounds.size = self.flex.intrinsicSize
}
```