### PR TITLE
Add direction property in Flex class

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,10 @@ This section describes all flex container's properties.
 - Default value: `column`
 - CSS name: `flex-direction` 
 
+**Property:**
+
+* **`direction: Direction?`**  
+
 **Method:**
 
 * **`direction(_: Direction)`**  
@@ -752,16 +756,6 @@ Get the size of view when layouted in a container with a width of 200 pixels.
 
 * **`intrinsicSize`**  
 Item natural size, considering only properties of the view itself. Independent of the item frame.
-
-<br>
-
-### direction
-- Applies to: `flex items`
-
-**Property:**
-
-* **`direction`**  
-This `direction` property is get the direction flex items are placed in the flex container.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -755,6 +755,16 @@ Item natural size, considering only properties of the view itself. Independent o
 
 <br>
 
+### direction
+- Applies to: `flex items`
+
+**Property:**
+
+* **`direction`**  
+This `direction` property is get the direction flex items are placed in the flex container.
+
+<br>
+
 <a name="absolute_positioning"></a>
 ## 4. Absolute positioning  
 - Applies to: `flex items`

--- a/Sources/Swift/FlexLayout.swift
+++ b/Sources/Swift/FlexLayout.swift
@@ -43,19 +43,6 @@ public final class Flex {
     public var intrinsicSize: CGSize {
         return yoga.intrinsicSize
     }
-
-    /**
-     This`direction` property is get the direction flex items are placed in the flex container.
-     */
-    public var direction: Direction? {
-        switch yoga.flexDirection {
-        case .column:           return Flex.Direction.column
-        case .columnReverse:    return Flex.Direction.columnReverse
-        case .row:              return Flex.Direction.row
-        case .rowReverse:       return Flex.Direction.rowReverse
-        @unknown default:       return nil
-        }
-    }
     
     init(view: UIView) {
         self.view = view
@@ -182,7 +169,34 @@ public final class Flex {
     //
     // MARK: Direction, wrap, flow
     //
-    
+
+    /**
+     The `direction` property establishes the main-axis, thus defining the direction flex items are placed in the flex container.
+
+     The `direction` property specifies how flex items are laid out in the flex container, by setting the direction of the flex
+     container’s main axis. They can be laid out in two main directions,  like columns vertically or like rows horizontally.
+
+     Note that row and row-reverse are affected by the layout direction (see `layoutDirection` property) of the flex container.
+     If its text direction is LTR (left to right), row represents the horizontal axis oriented from left to right, and row-reverse
+     from right to left; if the direction is rtl, it's the opposite.
+
+     - Parameter value: Default value is .column
+    */
+    public var direction: Direction? {
+        get {
+            switch yoga.flexDirection {
+            case .column:           return Flex.Direction.column
+            case .columnReverse:    return Flex.Direction.columnReverse
+            case .row:              return Flex.Direction.row
+            case .rowReverse:       return Flex.Direction.rowReverse
+            @unknown default:       return nil
+            }
+        }
+        set {
+            direction(newValue ?? .column)
+        }
+    }
+
     /**
      The `direction` property establishes the main-axis, thus defining the direction flex items are placed in the flex container.
     

--- a/Sources/Swift/FlexLayout.swift
+++ b/Sources/Swift/FlexLayout.swift
@@ -43,6 +43,19 @@ public final class Flex {
     public var intrinsicSize: CGSize {
         return yoga.intrinsicSize
     }
+
+    /**
+     This`direction` property is get the direction flex items are placed in the flex container.
+     */
+    public var direction: Direction? {
+        switch yoga.flexDirection {
+        case .column:           return Flex.Direction.column
+        case .columnReverse:    return Flex.Direction.columnReverse
+        case .row:              return Flex.Direction.row
+        case .rowReverse:       return Flex.Direction.rowReverse
+        @unknown default:       return nil
+        }
+    }
     
     init(view: UIView) {
         self.view = view


### PR DESCRIPTION
It's used when a layout needs to be changed according to the direction of a flex item.

For example, when developing an UI component, you can use it to change the layout according to the direction of the super container view.

```
flex.addItem().direction(.row).define { flex in
    FlexUIComponentItem()
        .direction(flex.direction) <--
}
```