### PR TITLE
Adds SWIFT_PACKAGE preprocessor definition

### DIFF
--- a/Sources/Swift/FlexLayout.swift
+++ b/Sources/Swift/FlexLayout.swift
@@ -13,7 +13,7 @@
 // Created by Luc Dion on 2017-06-19.
 
 import UIKit
-#if FLEXLAYOUT_SWIFT_PACKAGE
+#if FLEXLAYOUT_SWIFT_PACKAGE || SWIFT_PACKAGE
 import FlexLayoutYogaKit
 #endif
 

--- a/Sources/Swift/Impl/FlexLayout+Enum.swift
+++ b/Sources/Swift/Impl/FlexLayout+Enum.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-#if FLEXLAYOUT_SWIFT_PACKAGE
+#if FLEXLAYOUT_SWIFT_PACKAGE || SWIFT_PACKAGE
 import FlexLayoutYoga
 
 extension YGFlexDirection {

--- a/Sources/Swift/Impl/FlexLayout+Private.swift
+++ b/Sources/Swift/Impl/FlexLayout+Private.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-#if FLEXLAYOUT_SWIFT_PACKAGE
+#if FLEXLAYOUT_SWIFT_PACKAGE || SWIFT_PACKAGE
 import FlexLayoutYoga
 #endif
 

--- a/Sources/Swift/YGLayoutExtensions.swift
+++ b/Sources/Swift/YGLayoutExtensions.swift
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#if FLEXLAYOUT_SWIFT_PACKAGE
+#if FLEXLAYOUT_SWIFT_PACKAGE || SWIFT_PACKAGE
 import CoreGraphics
 import FlexLayoutYoga
 #endif

--- a/Sources/YogaKit/include/YogaKit/YGLayout+Private.h
+++ b/Sources/YogaKit/include/YogaKit/YGLayout+Private.h
@@ -6,7 +6,7 @@
  */
 
 #import "YGLayout.h"
-#if FLEXLAYOUT_SWIFT_PACKAGE
+#if FLEXLAYOUT_SWIFT_PACKAGE || SWIFT_PACKAGE
 #import <yoga/Yoga.h>
 #else
 #import "Yoga.h"

--- a/Sources/YogaKit/include/YogaKit/YGLayout.h
+++ b/Sources/YogaKit/include/YogaKit/YGLayout.h
@@ -7,7 +7,7 @@
 
 #import <UIKit/UIKit.h>
 
-#if FLEXLAYOUT_SWIFT_PACKAGE
+#if FLEXLAYOUT_SWIFT_PACKAGE || SWIFT_PACKAGE
 #import <yoga/YGEnums.h>
 #import <yoga/Yoga.h>
 #import <yoga/YGMacros.h>


### PR DESCRIPTION
Adds `SWIFT_PACKAGE` flag for resolving correct path to yoga imports.

Fixes issue https://github.com/layoutBox/FlexLayout/issues/219 where including FlexLayout as a dependency of another swift package would fail to build - because it isn't possible to set the preprocessor definition `FLEXLAYOUT_SWIFT_PACKAGE=1` without an Xcode project.

From the [SPM Documentation](https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#packaging-legacy-code):

>You may be working with code that builds both as a package and not. For example, you may be packaging a project that also builds with Xcode.
>
>In these cases, you can use the preprocessor definition SWIFT_PACKAGE to conditionally compile code for Swift packages.
>
>In your source file:
>
>```
> #if SWIFT_PACKAGE
> import Foundation
> #endif

**edit**: I have update this PR to avoid breaking changes. It now avoids removing the `FLEXLAYOUT_SWIFT_PACKAGE` flag that people are already using.

```
#if FLEXLAYOUT_SWIFT_PACKAGE || SWIFT_PACKAGE