### PR TITLE
Fixes an issue where `YGApplyLayoutToViewHierarchy` assigns a value to `frame.size` that does not rounded to the pixel grid.

### DIFF
--- a/Sources/YogaKit/YGLayout.mm
+++ b/Sources/YogaKit/YGLayout.mm
@@ -525,8 +525,8 @@ static void YGApplyLayoutToViewHierarchy(UIView *view, BOOL preserveOrigin)
       .y = YGRoundPixelValue(topLeft.y + origin.y),
     },
     .size = {
-      .width = MAX(0, YGRoundPixelValue(bottomRight.x) - YGRoundPixelValue(topLeft.x)),
-      .height = MAX(0, YGRoundPixelValue(bottomRight.y) - YGRoundPixelValue(topLeft.y)),
+      .width = MAX(0, YGRoundPixelValue(bottomRight.x - topLeft.x)),
+      .height = MAX(0, YGRoundPixelValue(bottomRight.y - topLeft.y)),
     },
   };
 


### PR DESCRIPTION
This PR changes the `YGApplyLayoutToViewHierarchy` method to call `YGRoundPixelValue` last after subtraction when calculating `size`, to fix an issue that caused ellipses in `UILabel` due to the low decimal accuracy of `float`.