### PR TITLE
Remove `FlexLayoutYoga` duplicate dependency in Swift Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
   targets: [
     .target(
       name: "FlexLayout",
-      dependencies: ["FlexLayoutYoga", "FlexLayoutYogaKit"],
+      dependencies: ["FlexLayoutYogaKit"],
       path: "Sources/Swift",
       publicHeadersPath: "Public"
     ),


### PR DESCRIPTION
## Background

- `FlexLayoutYoga` is being linked unnecessarily twice (`FlexLayout`, `FlexLayoutYogaKit`)

## Contents

- Remove `FlexLayoutYoga` dependency in `FlexLayout` target