### PR TITLE
Support `align-content`: `space-evenly`

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - FlexLayout (2.0.8)
+  - FlexLayout (2.0.9)
   - PinLayout (1.10.5)
   - SwiftLint (0.55.1)
 
@@ -18,7 +18,7 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  FlexLayout: 74c80db7698ea6e0d11e00ba012c0b9f3252938a
+  FlexLayout: 6904d99efeb7279cb218d10f40a71c4690445ada
   PinLayout: f6c2b63a5a5b24864064e1d15c67de41b4e74748
   SwiftLint: 3fe909719babe5537c552ee8181c0031392be933
 

--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ Reminder: the cross axis is the axis perpendicular to the main axis. Its directi
 
 ### alignContent()
 - Applies to: `flex containers`
-- Values: `start` / `end` / `center` / `stretch` / `spaceBetween` / `spaceAround`
+- Values: `start` / `end` / `center` / `stretch` / `spaceBetween` / `spaceAround` / `spaceEvenly`
 - Default value: `start`
 - CSS name: `align-content`  
 
@@ -600,6 +600,7 @@ Note, `alignContent` has no effect when the flexbox has only a single line.
 | **stretch**	| <img src="docs_markdown/images/flexlayout-alignItems-column-stretch.png" width="140"/>| <img src="docs_markdown/images/flexlayout-alignItems-row-stretch.png" width="160"/>|
 | **spaceBetween** | <img src="docs_markdown/images/flexlayout-alignItems-column-spaceBetween.png" width="160"/> | <img src="docs_markdown/images/flexlayout-alignItems-row-spaceBetween.png" width="160"/>|
 | **spaceAround** | <img src="docs_markdown/images/flexlayout-alignItems-column-spaceAround.png" width="160"/> | <img src="docs_markdown/images/flexlayout-alignItems-row-spaceAround.png" width="160"/>|
+| **spaceEvenly** | | |
 
 <br/>
 

--- a/Sources/Swift/FlexLayout.swift
+++ b/Sources/Swift/FlexLayout.swift
@@ -1382,6 +1382,9 @@ public final class Flex {
         case spaceBetween
         /// Lines are evenly distributed in the flex container, with half-size spaces on either end	Play it »
         case spaceAround
+        /// Lines are evenly distributed in the flex container
+        /// The size of gaps between children and between the parent's edges and the first/last child will all be equal
+        case spaceEvenly
     }
     
     /**

--- a/Sources/Swift/Impl/FlexLayout+Enum.swift
+++ b/Sources/Swift/Impl/FlexLayout+Enum.swift
@@ -42,6 +42,7 @@ extension YGAlign {
     static let flexEnd = YGAlignFlexEnd
     static let spaceBetween = YGAlignSpaceBetween
     static let spaceAround = YGAlignSpaceAround
+    static let spaceEvenly = YGAlignSpaceEvenly
 }
 
 extension YGWrap {
@@ -106,6 +107,7 @@ extension Flex.AlignContent {
         case .end:          return YGAlign.flexEnd
         case .spaceBetween: return YGAlign.spaceBetween
         case .spaceAround:  return YGAlign.spaceAround
+        case .spaceEvenly:  return YGAlign.spaceEvenly
         }
     }
 }


### PR DESCRIPTION
## Background
- Support for align-content: space-evenly in yoga 3
- https://www.yogalayout.dev/blog/announcing-yoga-3.0#better-support-for-multiline-containers