### PR TITLE
Add SPM platform setting

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
   name: "FlexLayout",
+  platforms: [
+    .iOS(.v12)
+  ],
   products: [
     .library(name: "FlexLayout", targets: ["FlexLayout"]),
   ],

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - FlexLayout (2.0.9)
+  - FlexLayout (2.0.10)
   - PinLayout (1.10.5)
   - SwiftLint (0.55.1)
 
@@ -18,7 +18,7 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  FlexLayout: 6904d99efeb7279cb218d10f40a71c4690445ada
+  FlexLayout: ea94491c923485f7f28891cb5b10245d22df380b
   PinLayout: f6c2b63a5a5b24864064e1d15c67de41b4e74748
   SwiftLint: 3fe909719babe5537c552ee8181c0031392be933
 


### PR DESCRIPTION
Specify SPM supported platforms, same as in CocoaPods

```ruby
Pod::Spec.new do |spec|
  spec.platform     = :ios, "12.0"
  ...
```

https://github.com/layoutBox/FlexLayout/issues/258