### PR TITLE
Update documentation link for 'Show on Github'

### DIFF
--- a/docs/1.1/Classes/Flex.html
+++ b/docs/1.1/Classes/Flex.html
@@ -117,7 +117,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L38">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L38">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -147,7 +147,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L44-L46">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L44-L46">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -192,7 +192,7 @@
                         <p>The added view flex interface</p>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L66-L69">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L68-L72">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -246,7 +246,7 @@ UIView, adds it has subviews and enables flexbox. This is useful to add a flex i
                         <p>The added view flex interface</p>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L79-L82">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L82-L90">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -301,7 +301,7 @@ and containers.</p>
                         <p>Flex interface</p>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L93-L96">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L100-L104">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -361,7 +361,7 @@ and containers.</p>
                         </table>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L107-L113">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L115-L121">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -392,7 +392,7 @@ flexbox&rsquo;s UIView is excluded, FlexLayout won&rsquo;t layout the view and i
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L119-L123">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L127-L134">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -446,7 +446,7 @@ flexbox&rsquo;s UIView is excluded, FlexLayout won&rsquo;t layout the view and i
                         <p></p>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L133-L136">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L143-L147">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -484,7 +484,7 @@ using <code>markDirty()</code>.</p>
                         <p>Flex interface</p>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L148-L151">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L158-L162">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -537,7 +537,7 @@ using <code>markDirty()</code>.</p>
                         <p>item size</p>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L159-L161">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L170-L172">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -604,7 +604,7 @@ from right to left; if the direction is rtl, it&rsquo;s the opposite.</p>
                         </table>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L180-L183">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L215-L219">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -653,7 +653,7 @@ from right to left; if the direction is rtl, it&rsquo;s the opposite.</p>
                         </table>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L191-L194">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L226-L230">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -708,7 +708,7 @@ root of your layout tree.</p>
                         <p></p>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L205-L220">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L240-L256">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -770,7 +770,7 @@ size. For example, if children are flowing vertically, <code>justifyContent</cod
                         </table>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L234-L237">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L269-L273">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -821,7 +821,7 @@ children are flowing vertically, <code>alignItems</code> controls how they align
                         </table>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L247-L250">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L282-L286">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -872,7 +872,7 @@ will align horizontally.</p>
                         </table>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L260-L263">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L295-L299">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -922,7 +922,7 @@ in the cross-axis, similar to how justifyContent aligns individual items within 
                         </table>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L272-L275">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L307-L311">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -984,7 +984,7 @@ item should take up.</p>
                         </table>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L295-L298">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L330-L334">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1040,7 +1040,7 @@ overflow its flex container.</p>
                         </table>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L313-L316">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L348-L352">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1093,7 +1093,7 @@ item has no length specified, the length will be according to its content.</p>
                         </table>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L328-L331">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L363-L367">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1134,7 +1134,7 @@ item has no length specified, the length will be according to its content.</p>
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L341-L344">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L389-L393">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1165,7 +1165,7 @@ Example: view.flex.width(20%)</p>
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L351-L354">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L399-L403">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1195,7 +1195,7 @@ Example: view.flex.width(20%)</p>
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L360-L363">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L408-L412">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1226,7 +1226,7 @@ Example: view.flex.height(40%)</p>
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L370-L373">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L418-L422">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1256,7 +1256,7 @@ Example: view.flex.height(40%)</p>
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L379-L383">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L427-L432">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1286,7 +1286,7 @@ Example: view.flex.height(40%)</p>
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L389-L393">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L437-L442">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1316,7 +1316,7 @@ Example: view.flex.height(40%)</p>
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L399-L402">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L447-L451">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1346,7 +1346,7 @@ Example: view.flex.height(40%)</p>
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L408-L411">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L456-L460">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1376,7 +1376,7 @@ Example: view.flex.height(40%)</p>
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L417-L420">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L465-L469">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1406,7 +1406,7 @@ Example: view.flex.height(40%)</p>
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L426-L429">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L474-L478">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1436,7 +1436,7 @@ Example: view.flex.height(40%)</p>
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L435-L438">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L483-L487">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1466,7 +1466,7 @@ Example: view.flex.height(40%)</p>
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L444-L447">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L492-L496">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1496,7 +1496,7 @@ Example: view.flex.height(40%)</p>
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L453-L457">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L501-L506">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1526,7 +1526,7 @@ Example: view.flex.height(40%)</p>
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L463-L466">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L511-L515">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1581,7 +1581,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         <p></p>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L477-L480">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L525-L529">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1636,7 +1636,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         <p></p>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L491-L496">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L539-L545">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1696,7 +1696,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </table>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L508-L511">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L556-L560">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1726,7 +1726,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L517-L520">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L566-L570">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1756,7 +1756,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L526-L529">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L586-L590">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1786,7 +1786,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L535-L538">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L606-L610">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1816,7 +1816,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L544-L547">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L626-L630">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1846,7 +1846,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L553-L556">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L646-L650">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1876,7 +1876,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L562-L565">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L667-L671">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1917,7 +1917,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L575-L578">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L767-L771">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1947,7 +1947,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L581-L584">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L773-L777">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -1977,7 +1977,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L590-L593">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L782-L786">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2007,7 +2007,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L596-L599">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L788-L792">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2037,7 +2037,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L605-L608">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L797-L801">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2067,7 +2067,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L611-L614">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L803-L807">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2097,7 +2097,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L620-L623">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L812-L816">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2127,7 +2127,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L626-L629">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L818-L822">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2164,7 +2164,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L639-L642">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L831-L835">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2194,7 +2194,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L645-L648">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L837-L841">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2231,7 +2231,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L658-L661">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L850-L854">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2261,7 +2261,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L664-L667">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L856-L860">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2291,7 +2291,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L673-L676">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L865-L869">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2321,7 +2321,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L679-L682">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L871-L875">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2351,7 +2351,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L688-L691">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L880-L884">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2381,7 +2381,7 @@ media types. AspectRatio accepts any floating point value &gt; 0, the default is
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L694-L697">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L886-L890">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2412,7 +2412,7 @@ This method is particularly useful to set all margins using iOS 11 <code>UIView.
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L704-L710">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L896-L903">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2442,7 +2442,7 @@ This method is particularly useful to set all margins using iOS 11 <code>UIView.
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L732-L735">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L921-L925">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2472,7 +2472,7 @@ This method is particularly useful to set all margins using iOS 11 <code>UIView.
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L738-L741">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L927-L931">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2502,7 +2502,7 @@ This method is particularly useful to set all margins using iOS 11 <code>UIView.
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L779-L785">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L972-L979">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2532,7 +2532,7 @@ This method is particularly useful to set all margins using iOS 11 <code>UIView.
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L788-L794">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L981-L988">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2573,7 +2573,7 @@ This method is particularly useful to set all margins using iOS 11 <code>UIView.
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L804-L807">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L997-L1001">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2603,7 +2603,7 @@ This method is particularly useful to set all margins using iOS 11 <code>UIView.
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L813-L816">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1012-L1016">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2633,7 +2633,7 @@ This method is particularly useful to set all margins using iOS 11 <code>UIView.
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L822-L825">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1027-L1031">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2663,7 +2663,7 @@ This method is particularly useful to set all margins using iOS 11 <code>UIView.
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L831-L834">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1042-L1046">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2700,7 +2700,7 @@ This method is particularly useful to set all margins using iOS 11 <code>UIView.
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L844-L847">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1061-L1065">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2737,7 +2737,7 @@ This method is particularly useful to set all margins using iOS 11 <code>UIView.
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L857-L860">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1080-L1084">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2767,7 +2767,7 @@ This method is particularly useful to set all margins using iOS 11 <code>UIView.
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L866-L869">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1095-L1099">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2797,7 +2797,7 @@ This method is particularly useful to set all margins using iOS 11 <code>UIView.
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L875-L878">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1110-L1114">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2828,7 +2828,7 @@ This method is particularly useful to set all paddings using iOS 11 <code>UIView
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L885-L891">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1126-L1133">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2858,7 +2858,7 @@ This method is particularly useful to set all paddings using iOS 11 <code>UIView
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L914-L917">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1151-L1155">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2888,7 +2888,7 @@ This method is particularly useful to set all paddings using iOS 11 <code>UIView
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L942-L948">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1202-L1209">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2952,7 +2952,7 @@ This method is particularly useful to set all paddings using iOS 11 <code>UIView
                         <p>flex interface</p>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L961-L964">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1273-L1281">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -2993,7 +2993,7 @@ This method is particularly useful to set all paddings using iOS 11 <code>UIView
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L970-L979">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1349-L1358">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -3023,7 +3023,7 @@ This method is particularly useful to set all paddings using iOS 11 <code>UIView
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L983-L995">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1362-L1375">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -3053,7 +3053,7 @@ This method is particularly useful to set all paddings using iOS 11 <code>UIView
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L999-L1012">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1379-L1395">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -3083,7 +3083,7 @@ This method is particularly useful to set all paddings using iOS 11 <code>UIView
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1016-L1027">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1399-L1410">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -3113,7 +3113,7 @@ This method is particularly useful to set all paddings using iOS 11 <code>UIView
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1031-L1044">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1414-L1427">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -3143,7 +3143,7 @@ This method is particularly useful to set all paddings using iOS 11 <code>UIView
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1048-L1055">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1431-L1438">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -3173,7 +3173,7 @@ This method is particularly useful to set all paddings using iOS 11 <code>UIView
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1059-L1064">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1442-L1449">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -3203,7 +3203,7 @@ This method is particularly useful to set all paddings using iOS 11 <code>UIView
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1068-L1076">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1453-L1461">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -3234,7 +3234,7 @@ This method is particularly useful to set all paddings using iOS 11 <code>UIView
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1081-L1088">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1466-L1473">Show on GitHub</a>
                       </div>
                     </section>
                   </div>

--- a/docs/1.1/Classes/Flex/AlignContent.html
+++ b/docs/1.1/Classes/Flex/AlignContent.html
@@ -105,7 +105,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1001">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1381">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -139,7 +139,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1003">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1383">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -173,7 +173,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1005">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1385">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -207,7 +207,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1007">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1387">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -241,7 +241,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1009">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1389">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -275,7 +275,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1011">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1391">Show on GitHub</a>
                       </div>
                     </section>
                   </div>

--- a/docs/1.1/Classes/Flex/AlignItems.html
+++ b/docs/1.1/Classes/Flex/AlignItems.html
@@ -105,7 +105,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1018">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1401">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -139,7 +139,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1020">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1403">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -173,7 +173,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1022">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1405">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -207,7 +207,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1024">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1407">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -241,7 +241,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1026">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1409">Show on GitHub</a>
                       </div>
                     </section>
                   </div>

--- a/docs/1.1/Classes/Flex/AlignSelf.html
+++ b/docs/1.1/Classes/Flex/AlignSelf.html
@@ -105,7 +105,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1033">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1416">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -139,7 +139,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1035">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1418">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -173,7 +173,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1037">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1420">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -207,7 +207,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1039">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1422">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -241,7 +241,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1041">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1424">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -275,7 +275,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1043">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1426">Show on GitHub</a>
                       </div>
                     </section>
                   </div>

--- a/docs/1.1/Classes/Flex/Direction.html
+++ b/docs/1.1/Classes/Flex/Direction.html
@@ -105,7 +105,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L972">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1351">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -139,7 +139,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L974">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1353">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -173,7 +173,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L976">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1355">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -207,7 +207,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L978">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1357">Show on GitHub</a>
                       </div>
                     </section>
                   </div>

--- a/docs/1.1/Classes/Flex/JustifyContent.html
+++ b/docs/1.1/Classes/Flex/JustifyContent.html
@@ -105,7 +105,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L985">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1364">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -139,7 +139,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L987">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1366">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -173,7 +173,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L989">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1368">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -207,7 +207,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L991">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1370">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -241,7 +241,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L993">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1372">Show on GitHub</a>
                       </div>
                     </section>
                   </div>

--- a/docs/1.1/Classes/Flex/LayoutDirection.html
+++ b/docs/1.1/Classes/Flex/LayoutDirection.html
@@ -105,7 +105,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1070">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1455">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -139,7 +139,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1072">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1457">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -173,7 +173,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1074">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1459">Show on GitHub</a>
                       </div>
                     </section>
                   </div>

--- a/docs/1.1/Classes/Flex/LayoutMode.html
+++ b/docs/1.1/Classes/Flex/LayoutMode.html
@@ -106,7 +106,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1083">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1468">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -140,7 +140,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1085">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1470">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -174,7 +174,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1087">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1472">Show on GitHub</a>
                       </div>
                     </section>
                   </div>

--- a/docs/1.1/Classes/Flex/Position.html
+++ b/docs/1.1/Classes/Flex/Position.html
@@ -105,7 +105,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1432">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1444">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -139,7 +139,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1432">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1446">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -173,7 +173,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1432">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1448">Show on GitHub</a>
                       </div>
                     </section>
                   </div>

--- a/docs/1.1/Classes/Flex/Wrap.html
+++ b/docs/1.1/Classes/Flex/Wrap.html
@@ -105,7 +105,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1050">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1433">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -139,7 +139,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1052">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1435">Show on GitHub</a>
                       </div>
                     </section>
                   </div>
@@ -173,7 +173,7 @@
                         </div>
                       </div>
                       <div class="slightly-smaller">
-                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/FlexLayout.swift#L1054">Show on GitHub</a>
+                        <a href="https://github.com/lucdion/FlexLayout/tree/master/Sources/Swift/FlexLayout.swift#L1437">Show on GitHub</a>
                       </div>
                     </section>
                   </div>


### PR DESCRIPTION
I found and corrected several incorrect GitHub links in the documentation.