### PR TITLE
Fix build failure issue on Carthage

### DIFF
--- a/Example/cocoapods/FlexLayoutSample.xcodeproj/project.pbxproj
+++ b/Example/cocoapods/FlexLayoutSample.xcodeproj/project.pbxproj
@@ -199,7 +199,7 @@
 		249EFE361E64FAFE00165E39 = {
 			isa = PBXGroup;
 			children = (
-				249EFE411E64FAFE00165E39 /* ../FlexLayoutSample */,
+				249EFE411E64FAFE00165E39 /* FlexLayoutSample */,
 				461884C59B72ACEAFC912B8A /* Frameworks */,
 				85CAAE97812075333AF3E88F /* Pods */,
 				249EFE401E64FAFE00165E39 /* Products */,
@@ -214,7 +214,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		249EFE411E64FAFE00165E39 /* ../FlexLayoutSample */ = {
+		249EFE411E64FAFE00165E39 /* FlexLayoutSample */ = {
 			isa = PBXGroup;
 			children = (
 				2439CC671E66614D003326FB /* Supporting Files */,
@@ -364,7 +364,6 @@
 				DF1F2A141F17D11700BA1B97 /* Frameworks */,
 				DF1F2A181F17D11700BA1B97 /* Resources */,
 				DF1F2A1B1F17D11700BA1B97 /* Embed Frameworks */,
-				DF1F2A1C1F17D11700BA1B97 /* [CP] Embed Pods Frameworks */,
 				DF1F2A1E1F17D11700BA1B97 /* Run Swiftlint */,
 			);
 			buildRules = (
@@ -440,28 +439,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		DF1F2A1C1F17D11700BA1B97 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-FlexLayoutSample/Pods-FlexLayoutSample-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Yoga/yoga.framework",
-				"${BUILT_PRODUCTS_DIR}/FlexLayout/FlexLayout.framework",
-				"${BUILT_PRODUCTS_DIR}/PinLayout/PinLayout.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/yoga.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FlexLayout.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PinLayout.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-FlexLayoutSample/Pods-FlexLayoutSample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		DF1F2A1E1F17D11700BA1B97 /* Run Swiftlint */ = {

--- a/FlexLayout.xcodeproj/project.pbxproj
+++ b/FlexLayout.xcodeproj/project.pbxproj
@@ -276,7 +276,6 @@
 				780CC5362B9779C60FF80C2D /* [CP] Check Pods Manifest.lock */,
 				24DA375F1EF843C500D1AB2F /* Sources */,
 				24DA37601EF843C500D1AB2F /* Frameworks */,
-				1CCE19B4893250DCBCF5F00C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -341,26 +340,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1CCE19B4893250DCBCF5F00C /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-FlexLayoutTests/Pods-FlexLayoutTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Yoga/yoga.framework",
-				"${BUILT_PRODUCTS_DIR}/FlexLayout/FlexLayout.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/yoga.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FlexLayout.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-FlexLayoutTests/Pods-FlexLayoutTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		296ABF4DC2205E5C45A6CE32 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 source 'https://cdn.cocoapods.org/'
-use_frameworks!
+use_frameworks! :linkage => :static
 platform :ios, '13.4'
 
 workspace 'FlexLayout.xcworkspace'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - FlexLayout (2.1.0):
+  - FlexLayout (2.2.0):
     - Yoga (= 3.2.1)
   - PinLayout (1.10.5)
   - SwiftLint (0.55.1)
@@ -22,11 +22,11 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  FlexLayout: 4832b2e2069002e7d3f48dffbb20cc773a1813be
+  FlexLayout: a8947ca2446760b5203ba5a3d862023c92a82fce
   PinLayout: f6c2b63a5a5b24864064e1d15c67de41b4e74748
   SwiftLint: 3fe909719babe5537c552ee8181c0031392be933
   Yoga: 636ce73bd247407928a7df089f3bc3675916b3ff
 
-PODFILE CHECKSUM: de7bb13eccf1a1ff875980af83b7d4a0cba2ca59
+PODFILE CHECKSUM: e95bd8fefde1bd2741249ea540133b9a4393b01f
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/README.md
+++ b/README.md
@@ -1160,7 +1160,7 @@ carthage update --no-build
 carthage build --use-xcframeworks
 ```
 
-3. Add the built `FlexLayout.framework` from the `Carthage/Build` folder to the **Embedded Binaries** section of your Xcode project.
+3. Add built `FlexLayout.xcframework` in your Xcode project in the **Embedded Binaries** section.
 
 
 ### Swift Package Manager

--- a/README.md
+++ b/README.md
@@ -1153,8 +1153,14 @@ To integrate FlexLayout into your Xcode project using Carthage:
 github "layoutBox/FlexLayout"
 ```
 
-2. Run `carthage update` to build frameworks.
-3. Add built `FlexLayout.framework` in your Xcode project in the **Embedded Binaries** section. 
+2. Run the following commands to resolve dependencies and build:
+```bash
+carthage update --no-build
+(cd ./Carthage/Checkouts/FlexLayout && pod install)
+carthage build --use-xcframeworks
+```
+
+3. Add the built `FlexLayout.framework` from the `Carthage/Build` folder to the **Embedded Binaries** section of your Xcode project.
 
 
 ### Swift Package Manager

--- a/Sources/Swift/Public/FlexLayout.h
+++ b/Sources/Swift/Public/FlexLayout.h
@@ -24,7 +24,7 @@ FOUNDATION_EXPORT double FlexLayoutVersionNumber;
 FOUNDATION_EXPORT const unsigned char FlexLayoutVersionString[];
 
 // In this header, you should import all the public headers of your framework using
-#import "Yoga.h"
-#import "YGEnums.h"
-#import "YGMacros.h"
-#import "YGValue.h"
+#import <yoga/Yoga.h>
+#import <yoga/YGEnums.h>
+#import <yoga/YGMacros.h>
+#import <yoga/YGValue.h>


### PR DESCRIPTION
## What is this PR?

Since version 2.1.0, Yoga is managed as a separate dependency, so the project cannot be built on its own. Therefore, it cannot be used with Carthage.

Providing a pre-built static framework or adopting a different structure would require significant changes.
Instead, this PR updates the guide and some settings to maintain the current project structure while enabling Carthage support.

## Test
spm ✅
cocoapods ✅
carthage ✅

[FlexLayoutTest.zip](https://github.com/user-attachments/files/20607329/FlexLayoutTest.zip)

close #270 
